### PR TITLE
Add QEMU patch to support building with libnfs6.0

### DIFF
--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -21,6 +21,7 @@ readonly QEMU_URL="https://download.qemu.org/${QEMU_ARCHIVE}"
 readonly QEMU_SIG_URL="${QEMU_URL}.sig"
 readonly PATCH_DIR="../../patches/QEMU"
 readonly QEMU_PATCH="${CPU_VENDOR}-${QEMU_DIR}.patch"
+readonly QEMU_LIBNFS_PATCH="${QEMU_DIR}-libnfs6.patch"
 readonly GPG_KEY="CEACC9E15534EBABB82D3FA03353C9CEF108B584"
 
 REQUIRED_PKGS_Arch=(
@@ -80,7 +81,19 @@ patch_qemu() {
     exit 1
   fi
 
-  fmtr::info "Applying patch to QEMU..."
+  if [ ! -f "${PATCH_DIR}/${QEMU_LIBNFS_PATCH}" ]; then
+    fmtr::error "Patch file ${PATCH_DIR}/${QEMU_LIBNFS_PATCH} not found!"
+    fmtr::fatal "Cannot proceed without the libnfs patch file. Exiting."
+    exit 1
+  fi
+
+  fmtr::info "Applying patches to QEMU..."
+
+  patch -fsp1 < "${PATCH_DIR}/${QEMU_LIBNFS_PATCH}" &>> "$LOG_FILE" || {
+    fmtr::error "Failed to apply patch ${QEMU_LIBNFS_PATCH}!"
+    fmtr::fatal "libNFS patch application failed. Please check the log for errors."
+    exit 1
+  }
 
   patch -fsp1 < "${PATCH_DIR}/${QEMU_PATCH}" &>> "$LOG_FILE" || {
     fmtr::error "Failed to apply patch ${QEMU_PATCH}!"

--- a/Hypervisor-Phantom/patches/QEMU/qemu-9.2.0-libnfs6.patch
+++ b/Hypervisor-Phantom/patches/QEMU/qemu-9.2.0-libnfs6.patch
@@ -1,0 +1,101 @@
+diff -Nurp qemu-9.2.0/block/nfs.c qemu-9.2.0-libnfs6/block/nfs.c
+--- qemu-9.2.0/block/nfs.c	2024-12-11 00:46:36.000000000 +0100
++++ qemu-9.2.0-libnfs6/block/nfs.c	2025-01-19 15:03:24.936846650 +0100
+@@ -70,7 +70,9 @@ typedef struct NFSRPC {
+     BlockDriverState *bs;
+     int ret;
+     int complete;
++#ifndef LIBNFS_API_V2
+     QEMUIOVector *iov;
++#endif
+     struct stat *st;
+     Coroutine *co;
+     NFSClient *client;
+@@ -246,6 +248,7 @@ nfs_co_generic_cb(int ret, struct nfs_co
+     NFSRPC *task = private_data;
+     task->ret = ret;
+     assert(!task->st);
++#ifndef LIBNFS_API_V2
+     if (task->ret > 0 && task->iov) {
+         if (task->ret <= task->iov->size) {
+             qemu_iovec_from_buf(task->iov, 0, data, task->ret);
+@@ -253,6 +256,7 @@ nfs_co_generic_cb(int ret, struct nfs_co
+             task->ret = -EIO;
+         }
+     }
++#endif
+     if (task->ret < 0) {
+         error_report("NFS Error: %s", nfs_get_error(nfs));
+     }
+@@ -266,15 +270,43 @@ static int coroutine_fn nfs_co_preadv(Bl
+ {
+     NFSClient *client = bs->opaque;
+     NFSRPC task;
++#ifdef LIBNFS_API_V2
++    char *buf = NULL;
++    bool my_buffer = false;
++#endif
+ 
+     nfs_co_init_task(bs, &task);
++
++#ifdef LIBNFS_API_V2
++    if (iov->niov != 1) {
++        buf = g_try_malloc(bytes);
++        if (bytes && buf == NULL) {
++            return -ENOMEM;
++        }
++        my_buffer = true;
++    } else {
++        buf = iov->iov[0].iov_base;
++    }
++#else
+     task.iov = iov;
++#endif
+ 
+     WITH_QEMU_LOCK_GUARD(&client->mutex) {
++#ifdef LIBNFS_API_V2
++        if (nfs_pread_async(client->context, client->fh,
++                            buf, bytes, offset,
++                            nfs_co_generic_cb, &task) != 0) {
++            if (my_buffer) {
++                g_free(buf);
++            }
++            return -ENOMEM;
++        }
++#else
+         if (nfs_pread_async(client->context, client->fh,
+                             offset, bytes, nfs_co_generic_cb, &task) != 0) {
+             return -ENOMEM;
+         }
++#endif
+ 
+         nfs_set_events(client);
+     }
+@@ -282,6 +314,15 @@ static int coroutine_fn nfs_co_preadv(Bl
+         qemu_coroutine_yield();
+     }
+ 
++#ifdef LIBNFS_API_V2
++    if (task.ret > 0) {
++        qemu_iovec_from_buf(iov, 0, buf, task.ret);
++    }
++    if (my_buffer) {
++        g_free(buf);
++    }
++#endif
++
+     if (task.ret < 0) {
+         return task.ret;
+     }
+@@ -318,7 +359,11 @@ static int coroutine_fn nfs_co_pwritev(B
+ 
+     WITH_QEMU_LOCK_GUARD(&client->mutex) {
+         if (nfs_pwrite_async(client->context, client->fh,
++#ifdef LIBNFS_API_V2
++                             buf, bytes, offset,
++#else
+                              offset, bytes, buf,
++#endif
+                              nfs_co_generic_cb, &task) != 0) {
+             if (my_buffer) {
+                 g_free(buf);


### PR DESCRIPTION
Currently, QEMU will fail to build on any system with libnfs >= 6.0.0. I observed this on my machine when trying to build the patched QEMU using spoof_qemu_patch.sh

This issue is discussed further here:

https://lists.nongnu.org/archive/html/qemu-block/2024-12/msg00151.html

I have added the patch supplied in the Arch repos to be applied before the build process, after doing so I was able to run the script on my machine and have the patched QEMU successfully build and install on my machine.

Please forgive any mistakes/errors, I am new to development

Thanks,
Liam Moss