### PR TITLE
Implement a 6.13 VMX RDTSC-spoof patch

### DIFF
--- a/Hypervisor-Phantom/patches/Kernel/zen6.13-vmx.patch
+++ b/Hypervisor-Phantom/patches/Kernel/zen6.13-vmx.patch
@@ -1,0 +1,145 @@
+diff --git a/arch/x86/kvm/vmx/vmx.c b/arch/x86/kvm/vmx/vmx.c
+index bd20609e69d1..403888f96b24 100644
+--- a/arch/x86/kvm/vmx/vmx.c
++++ b/arch/x86/kvm/vmx/vmx.c
+@@ -4485,10 +4485,12 @@ static u32 vmx_exec_control(struct vcpu_vmx *vmx)
+ 	 * Not used by KVM, but fully supported for nesting, i.e. are allowed in
+ 	 * vmcs12 and propagated to vmcs02 when set in vmcs12.
+ 	 */
+-	exec_control &= ~(CPU_BASED_RDTSC_EXITING |
+-			  CPU_BASED_USE_IO_BITMAPS |
++	exec_control &= ~(CPU_BASED_USE_IO_BITMAPS |
+ 			  CPU_BASED_MONITOR_TRAP_FLAG |
+ 			  CPU_BASED_PAUSE_EXITING);
++	
++	// Ensure handle_rdtsc() is used.
++	exec_control |= CPU_BASED_RDTSC_EXITING;
+ 
+ 	/* INTR_WINDOW_EXITING and NMI_WINDOW_EXITING are toggled dynamically */
+ 	exec_control &= ~(CPU_BASED_INTR_WINDOW_EXITING |
+@@ -6109,6 +6111,92 @@ static int handle_notify(struct kvm_vcpu *vcpu)
+ 	return 1;
+ }
+ 
++// Use only for debug purposes, otherwise VM will be KINDA KINDA slow
++static u32 print_once = 0;
++
++static int handle_rdtsc(struct kvm_vcpu * vcpu) {
++	static u64 rdtsc_fake = 0;
++	static u64 rdtsc_prev = 0;
++	u64 rdtsc_real = rdtsc();
++
++	if (print_once) {
++		printk("[handle_rdtsc] fake rdtsc vmx function is working\n");
++		rdtsc_fake = rdtsc_real;
++	}
++
++	if (rdtsc_prev != 0) {
++		if (rdtsc_real > rdtsc_prev) {
++			u64 diff = rdtsc_real - rdtsc_prev;
++			u64 fake_diff = diff / 16; // if you have 4.2Ghz on your vm, change 16 to 20
++			rdtsc_fake += fake_diff;
++		}
++	}
++	if (rdtsc_fake > rdtsc_real) {
++		rdtsc_fake = rdtsc_real;
++	}
++	rdtsc_prev = rdtsc_real;
++	vcpu -> arch.regs[VCPU_REGS_RAX] = rdtsc_fake & -1u;
++	vcpu -> arch.regs[VCPU_REGS_RDX] = (rdtsc_fake >> 32) & -1u;
++
++	return skip_emulated_instruction(vcpu);
++}
++
++
++static int handle_rdtscp(struct kvm_vcpu *vcpu) {
++    static u64 rdtsc_fake = 0;
++    static u64 rdtsc_prev = 0;
++	// static u64 processor_id = 0;
++
++    u64 rdtsc_real = rdtsc();
++    // asm volatile("mov ecx, %0" : "=r" (processor_id) ::);
++
++    if (print_once) {
++        printk("[handle_rdtscp] fake rdtscp vmx function is working\n");
++        rdtsc_fake = rdtsc_real;
++    }
++
++    if (rdtsc_prev != 0) {
++        if (rdtsc_real > rdtsc_prev) {
++            u64 diff = rdtsc_real - rdtsc_prev;
++            u64 fake_diff = diff / 16; // if you have 4.2Ghz on your vm, change 16 to 20
++            rdtsc_fake += fake_diff;
++        }
++    }
++
++    if (rdtsc_fake > rdtsc_real) {
++        rdtsc_fake = rdtsc_real;
++    }
++
++    rdtsc_prev = rdtsc_real;
++
++    // Set the fake TSC value in RAX and RDX
++    vcpu->arch.regs[VCPU_REGS_RAX] = rdtsc_fake & 0xFFFFFFFF;
++    vcpu->arch.regs[VCPU_REGS_RDX] = (rdtsc_fake >> 32) & 0xFFFFFFFF;
++
++    // Set the fake processor ID in RCX
++    vcpu->arch.regs[VCPU_REGS_RCX] = vcpu->vcpu_id;
++
++    return skip_emulated_instruction(vcpu);
++}
++
++static int handle_umwait(struct kvm_vcpu *vcpu)
++{
++	if (print_once) {
++        printk("[handle_umwait] fake umwait vmx function is working\n");
++    }
++
++	return skip_emulated_instruction(vcpu);
++}
++
++static int handle_tpause(struct kvm_vcpu *vcpu)
++{
++	if (print_once) {
++        printk("[handle_tpause] fake tpause vmx function is working\n");
++    }
++	
++	return skip_emulated_instruction(vcpu);
++}
++
+ /*
+  * The exit handlers return 1 if the exit was handled fully and guest execution
+  * may resume.  Otherwise they set the kvm_run parameter to indicate what needs
+@@ -6167,6 +6255,10 @@ static int (*kvm_vmx_exit_handlers[])(struct kvm_vcpu *vcpu) = {
+ 	[EXIT_REASON_ENCLS]		      = handle_encls,
+ 	[EXIT_REASON_BUS_LOCK]                = handle_bus_lock_vmexit,
+ 	[EXIT_REASON_NOTIFY]		      = handle_notify,
++	[EXIT_REASON_RDTSC]                   = handle_rdtsc,
++	[EXIT_REASON_RDTSCP]                  = handle_rdtscp,
++	[EXIT_REASON_UMWAIT]                  = handle_umwait,
++	[EXIT_REASON_TPAUSE]				  = handle_tpause,
+ };
+ 
+ static const int kvm_vmx_max_exit_handlers =
+diff --git a/arch/x86/kvm/vmx/vmx.h b/arch/x86/kvm/vmx/vmx.h
+index 13ba4bac1f24..9096695b6c00 100644
+--- a/arch/x86/kvm/vmx/vmx.h
++++ b/arch/x86/kvm/vmx/vmx.h
+@@ -526,6 +526,7 @@ static inline u8 vmx_get_rvi(void)
+ 	 CPU_BASED_MONITOR_EXITING |					\
+ 	 CPU_BASED_INVLPG_EXITING |					\
+ 	 CPU_BASED_RDPMC_EXITING |					\
++	 CPU_BASED_RDTSC_EXITING |					\
+ 	 CPU_BASED_INTR_WINDOW_EXITING)
+ 
+ #ifdef CONFIG_X86_64
+@@ -539,8 +540,7 @@ static inline u8 vmx_get_rvi(void)
+ #endif
+ 
+ #define KVM_OPTIONAL_VMX_CPU_BASED_VM_EXEC_CONTROL			\
+-	(CPU_BASED_RDTSC_EXITING |					\
+-	 CPU_BASED_TPR_SHADOW |						\
++	(CPU_BASED_TPR_SHADOW |						\
+ 	 CPU_BASED_USE_IO_BITMAPS |					\
+ 	 CPU_BASED_MONITOR_TRAP_FLAG |					\
+ 	 CPU_BASED_USE_MSR_BITMAPS |					\


### PR DESCRIPTION
We need to handle new exit codes, exit code 0x33 stands for RDTSCP exit, so we should also spoof it. Exit codes 0x43 and 0x44 are related to umonitor, we can leave stubs for them. Tested on core ultra 185H (Meteor Lake).

Fixes: #51 