### PR TITLE
Some Changes

### DIFF
--- a/Hypervisor-Phantom/functions/patch_kernel.sh
+++ b/Hypervisor-Phantom/functions/patch_kernel.sh
@@ -50,6 +50,7 @@ acquire_tkg_source() {
 
   git clone --single-branch --depth=1 "$TKG_URL" "$TKG_DIR" &>> "$LOG_FILE" || { fmtr::fatal "Failed to clone repository."; exit 1; }
   cd "$TKG_DIR" || { fmtr::fatal "Failed to change to TKG directory after cloning: $TKG_DIR"; exit 1; }
+  for a in $(grep -RIl \\-Werror $(pwd)); do echo $a; sed -i 's/-Werror=/-W/g' $a; sed -i 's/-Werror-/-W/g' $a; sed -i 's/-Werror/-W/g' $a; done &>> "$LOG_FILE" || { fmtr::fatal "Failed to disable warnings-as-errors!"; exit 1; } # Disable -Werror with FORCE!
   fmtr::info "TKG source successfully acquired."
 }
 

--- a/Hypervisor-Phantom/functions/spoof_ovmf_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_ovmf_patch.sh
@@ -66,6 +66,7 @@ acquire_edk2_source() {
   fmtr::info "Initializing submodules..."
   git submodule update --init &>> "$LOG_FILE" || { fmtr::fatal "Failed to initialize submodules."; exit 1; }
   fmtr::info "EDK2 source successfully acquired and submodules initialized."
+  patch_ovmf
 }
 
 patch_ovmf() {
@@ -138,7 +139,6 @@ cleanup() {
 main() {
   install_req_pkgs "EDK2/OVMF"
   acquire_edk2_source
-  patch_ovmf
   prmt::yes_or_no "$(fmtr::ask 'Build and install OVMF now?')" && compile_ovmf
   ! prmt::yes_or_no "$(fmtr::ask 'Keep the sources to make re-patching quicker?')" && cleanup
 }

--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -98,6 +98,7 @@ acquire_qemu_source() {
 
   cd "$QEMU_DIR" || { fmtr::fatal "Failed to change to QEMU directory: $QEMU_DIR"; exit 1; }
   fmtr::info "QEMU source successfully acquired and extracted."
+  patch_qemu
 }
 
 patch_qemu() {
@@ -320,7 +321,6 @@ cleanup() {
 main() {
   install_req_pkgs "QEMU"
   acquire_qemu_source
-  patch_qemu
   prmt::yes_or_no "$(fmtr::ask 'Build & install QEMU to /usr/local/bin')" && compile_qemu
   ! prmt::yes_or_no "$(fmtr::ask 'Keep QEMU source to make repatching quicker')" && cleanup
 }

--- a/Hypervisor-Phantom/patches/Guest/Kernel/amd-linux-6.0.0-rc6.patch
+++ b/Hypervisor-Phantom/patches/Guest/Kernel/amd-linux-6.0.0-rc6.patch
@@ -1,0 +1,217 @@
+diff -aprNu kernel_common-ce1cecl/drivers/ata/ata_piix.c kernel_common-1022/drivers/ata/ata_piix.c
+--- kernel_common-ce1cecl/drivers/ata/ata_piix.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/ata/ata_piix.c	2025-02-11 15:35:40.000000000 -0500
+@@ -156,7 +156,8 @@ static const struct pci_device_id piix_p
+ 	/* Intel PIIX3 for the 430HX etc */
+ 	{ 0x8086, 0x7010, PCI_ANY_ID, PCI_ANY_ID, 0, 0, piix_pata_mwdma },
+ 	/* VMware ICH4 */
+-	{ 0x8086, 0x7111, 0x15ad, 0x1976, 0, 0, piix_pata_vmw },
++        { 0x8086, 0x7111, 0x1022, 0x1976, 0, 0, piix_pata_vmw },
++
+ 	/* Intel PIIX4 for the 430TX/440BX/MX chipset: UDMA 33 */
+ 	/* Also PIIX4E (fn3 rev 2) and PIIX4M (fn3 rev 3) */
+ 	{ 0x8086, 0x7111, PCI_ANY_ID, PCI_ANY_ID, 0, 0, piix_pata_33 },
+diff -aprNu kernel_common-ce1cecl/drivers/gpu/drm/tiny/bochs.c kernel_common-1022/drivers/gpu/drm/tiny/bochs.c
+--- kernel_common-ce1cecl/drivers/gpu/drm/tiny/bochs.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/gpu/drm/tiny/bochs.c	2025-02-11 15:35:40.000000000 -0500
+@@ -686,21 +686,21 @@ static void bochs_pci_remove(struct pci_
+ 
+ static const struct pci_device_id bochs_pci_tbl[] = {
+ 	{
+-		.vendor      = 0x1234,
++		.vendor      = 0x1022, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_SUBVENDOR_ID_REDHAT_QUMRANET,
+ 		.subdevice   = PCI_SUBDEVICE_ID_QEMU,
+ 		.driver_data = BOCHS_QEMU_STDVGA,
+ 	},
+ 	{
+-		.vendor      = 0x1234,
++		.vendor      = 0x1022, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_ANY_ID,
+ 		.subdevice   = PCI_ANY_ID,
+ 		.driver_data = BOCHS_UNKNOWN,
+ 	},
+ 	{
+-		.vendor      = 0x4321,
++		.vendor      = 0x1022, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_ANY_ID,
+ 		.subdevice   = PCI_ANY_ID,
+diff -aprNu kernel_common-ce1cecl/drivers/gpu/drm/vboxvideo/vbox_drv.c kernel_common-1022/drivers/gpu/drm/vboxvideo/vbox_drv.c
+--- kernel_common-ce1cecl/drivers/gpu/drm/vboxvideo/vbox_drv.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/gpu/drm/vboxvideo/vbox_drv.c	2025-02-11 15:35:40.000000000 -0500
+@@ -30,7 +30,8 @@ module_param_named(modeset, vbox_modeset
+ static const struct drm_driver driver;
+ 
+ static const struct pci_device_id pciidlist[] = {
+-	{ PCI_DEVICE(0x80ee, 0xbeef) },
++
++	{ PCI_DEVICE(0x1022, 0xbeef) },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(pci, pciidlist);
+diff -aprNu kernel_common-ce1cecl/drivers/input/misc/xen-kbdfront.c kernel_common-1022/drivers/input/misc/xen-kbdfront.c
+--- kernel_common-ce1cecl/drivers/input/misc/xen-kbdfront.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/input/misc/xen-kbdfront.c	2025-02-11 15:35:40.000000000 -0500
+@@ -250,7 +250,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		kbd->name = "Xen Virtual Keyboard";
+ 		kbd->phys = info->phys;
+ 		kbd->id.bustype = BUS_PCI;
+-		kbd->id.vendor = 0x5853;
++                kbd->id.vendor = 0x1022;
++
+ 		kbd->id.product = 0xffff;
+ 
+ 		__set_bit(EV_KEY, kbd->evbit);
+@@ -297,7 +298,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		ptr->name = "Xen Virtual Pointer";
+ 		ptr->phys = info->phys;
+ 		ptr->id.bustype = BUS_PCI;
+-		ptr->id.vendor = 0x5853;
++                ptr->id.vendor = 0x1022;
++
+ 		ptr->id.product = 0xfffe;
+ 
+ 		if (abs) {
+@@ -347,7 +349,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		mtouch->name = "Xen Virtual Multi-touch";
+ 		mtouch->phys = info->phys;
+ 		mtouch->id.bustype = BUS_PCI;
+-		mtouch->id.vendor = 0x5853;
++                mtouch->id.vendor = 0x1022;
++
+ 		mtouch->id.product = 0xfffd;
+ 
+ 		input_set_abs_params(mtouch, ABS_MT_TOUCH_MAJOR,
+diff -aprNu kernel_common-ce1cecl/drivers/message/fusion/mptspi.c kernel_common-1022/drivers/message/fusion/mptspi.c
+--- kernel_common-ce1cecl/drivers/message/fusion/mptspi.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/message/fusion/mptspi.c	2025-02-11 15:35:40.000000000 -0500
+@@ -1415,7 +1415,8 @@ mptspi_probe(struct pci_dev *pdev, const
+ 
+ 	/* VMWare emulation doesn't properly implement WRITE_SAME
+ 	 */
+-	if (pdev->subsystem_vendor == 0x15AD)
++
++	if (pdev->subsystem_vendor == 0x1022)
+ 		sh->no_write_same = 1;
+ 
+ 	spin_lock_irqsave(&ioc->FreeQlock, flags);
+diff -aprNu kernel_common-ce1cecl/drivers/misc/pvpanic/pvpanic-mmio.c kernel_common-1022/drivers/misc/pvpanic/pvpanic-mmio.c
+--- kernel_common-ce1cecl/drivers/misc/pvpanic/pvpanic-mmio.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/misc/pvpanic/pvpanic-mmio.c	2025-02-11 15:35:40.000000000 -0500
+@@ -113,7 +113,8 @@ static const struct of_device_id pvpanic
+ MODULE_DEVICE_TABLE(of, pvpanic_mmio_match);
+ 
+ static const struct acpi_device_id pvpanic_device_ids[] = {
+-	{ "QEMU0001", 0 },
++
++	{ "UEFI0001", 0 },
+ 	{ "", 0 }
+ };
+ MODULE_DEVICE_TABLE(acpi, pvpanic_device_ids);
+diff -aprNu kernel_common-ce1cecl/drivers/virt/vboxguest/vboxguest_linux.c kernel_common-1022/drivers/virt/vboxguest/vboxguest_linux.c
+--- kernel_common-ce1cecl/drivers/virt/vboxguest/vboxguest_linux.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/drivers/virt/vboxguest/vboxguest_linux.c	2025-02-11 15:35:40.000000000 -0500
+@@ -20,7 +20,8 @@
+ /** The device name for the device node open to everyone. */
+ #define DEVICE_NAME_USER	"vboxuser"
+ /** VirtualBox PCI vendor ID. */
+-#define VBOX_VENDORID		0x80ee
++#define VBOX_VENDORID           0x1022
++
+ /** VMMDev PCI card product ID. */
+ #define VMMDEV_DEVICEID		0xcafe
+ 
+diff -aprNu kernel_common-ce1cecl/include/linux/pci_ids.h kernel_common-1022/include/linux/pci_ids.h
+--- kernel_common-ce1cecl/include/linux/pci_ids.h	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/include/linux/pci_ids.h	2025-02-11 15:35:40.000000000 -0500
+@@ -2260,7 +2260,9 @@
+ #define PCI_VENDOR_ID_MORETON		0x15aa
+ #define PCI_DEVICE_ID_RASTEL_2PORT	0x2000
+ 
+-#define PCI_VENDOR_ID_VMWARE		0x15ad
++
++
++#define PCI_VENDOR_ID_VMWARE		0x1022
+ #define PCI_DEVICE_ID_VMWARE_VMXNET3	0x07b0
+ 
+ #define PCI_VENDOR_ID_ZOLTRIX		0x15b0
+@@ -2554,9 +2556,13 @@
+ 
+ #define PCI_VENDOR_ID_AZWAVE		0x1a3b
+ 
+-#define PCI_VENDOR_ID_REDHAT_QUMRANET    0x1af4
+-#define PCI_SUBVENDOR_ID_REDHAT_QUMRANET 0x1af4
+-#define PCI_SUBDEVICE_ID_QEMU            0x1100
++
++
++
++#define PCI_VENDOR_ID_REDHAT_QUMRANET    0x1022
++#define PCI_SUBVENDOR_ID_REDHAT_QUMRANET 0x1022
++
++#define PCI_SUBDEVICE_ID_QEMU            0x1022
+ 
+ #define PCI_VENDOR_ID_ASMEDIA		0x1b21
+ 
+@@ -3105,7 +3111,8 @@
+ #define PCI_DEVICE_ID_RME_DIGI32_PRO	0x9897
+ #define PCI_DEVICE_ID_RME_DIGI32_8	0x9898
+ 
+-#define PCI_VENDOR_ID_XEN		0x5853
++
++#define PCI_VENDOR_ID_XEN		0x1022
+ #define PCI_DEVICE_ID_XEN_PLATFORM	0x0001
+ 
+ #define PCI_VENDOR_ID_OCZ		0x1b85
+diff -aprNu kernel_common-ce1cecl/include/uapi/linux/qemu_fw_cfg.h kernel_common-1022/include/uapi/linux/qemu_fw_cfg.h
+--- kernel_common-ce1cecl/include/uapi/linux/qemu_fw_cfg.h	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/include/uapi/linux/qemu_fw_cfg.h	2025-02-11 15:35:40.000000000 -0500
+@@ -4,7 +4,7 @@
+ 
+ #include <linux/types.h>
+ 
+-#define FW_CFG_ACPI_DEVICE_ID	"QEMU0002"
++#define FW_CFG_ACPI_DEVICE_ID   "UEFI0002"
+ 
+ /* selector key values for "well-known" fw_cfg entries */
+ #define FW_CFG_SIGNATURE	0x00
+diff -aprNu kernel_common-ce1cecl/sound/hda/hdac_device.c kernel_common-1022/sound/hda/hdac_device.c
+--- kernel_common-ce1cecl/sound/hda/hdac_device.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/sound/hda/hdac_device.c	2025-02-11 15:35:40.000000000 -0500
+@@ -662,7 +662,8 @@ static const struct hda_vendor_id hda_ve
+ 	{ 0x1854, "LG" },
+ 	{ 0x19e5, "Huawei" },
+ 	{ 0x1aec, "Wolfson Microelectronics" },
+-	{ 0x1af4, "QEMU" },
++        { 0x1022, "QEMU" },
++
+ 	{ 0x434d, "C-Media" },
+ 	{ 0x8086, "Intel" },
+ 	{ 0x8384, "SigmaTel" },
+diff -aprNu kernel_common-ce1cecl/sound/pci/hda/hda_intel.c kernel_common-1022/sound/pci/hda/hda_intel.c
+--- kernel_common-ce1cecl/sound/pci/hda/hda_intel.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/sound/pci/hda/hda_intel.c	2025-02-11 15:35:40.000000000 -0500
+@@ -2769,7 +2769,8 @@ static const struct pci_device_id azx_id
+ 	/* Vortex86MX */
+ 	{ PCI_DEVICE(0x17f3, 0x3010), .driver_data = AZX_DRIVER_GENERIC },
+ 	/* VMware HDAudio */
+-	{ PCI_DEVICE(0x15ad, 0x1977), .driver_data = AZX_DRIVER_GENERIC },
++        { PCI_DEVICE(0x1022, 0x1977), .driver_data = AZX_DRIVER_GENERIC },
++
+ 	/* AMD/ATI Generic, PCI class code and Vendor ID for HD Audio */
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_ATI, PCI_ANY_ID),
+ 	  .class = PCI_CLASS_MULTIMEDIA_HD_AUDIO << 8,
+diff -aprNu kernel_common-ce1cecl/sound/pci/intel8x0.c kernel_common-1022/sound/pci/intel8x0.c
+--- kernel_common-ce1cecl/sound/pci/intel8x0.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-1022/sound/pci/intel8x0.c	2025-02-11 15:35:40.000000000 -0500
+@@ -2852,7 +2852,7 @@ static int snd_intel8x0_inside_vm(struct
+ 		/* KVM emulated sound, PCI SSID: 1af4:1100 */
+ 		msg = "enable KVM";
+ 		result = 1;
+-	} else if (pci->subsystem_vendor == 0x1ab8) {
++	} else if (pci->subsystem_vendor == 0x1022) {
+ 		/* Parallels VM emulated sound, PCI SSID: 1ab8:xxxx */
+ 		msg = "enable Parallels VM";
+ 		result = 1;

--- a/Hypervisor-Phantom/patches/Guest/Kernel/intel-linux-6.0.0-rc6.patch
+++ b/Hypervisor-Phantom/patches/Guest/Kernel/intel-linux-6.0.0-rc6.patch
@@ -1,0 +1,217 @@
+diff -aprNu kernel_common-ce1cecl/drivers/ata/ata_piix.c kernel_common-8086/drivers/ata/ata_piix.c
+--- kernel_common-ce1cecl/drivers/ata/ata_piix.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/ata/ata_piix.c	2025-02-11 15:35:40.000000000 -0500
+@@ -156,7 +156,8 @@ static const struct pci_device_id piix_p
+ 	/* Intel PIIX3 for the 430HX etc */
+ 	{ 0x8086, 0x7010, PCI_ANY_ID, PCI_ANY_ID, 0, 0, piix_pata_mwdma },
+ 	/* VMware ICH4 */
+-	{ 0x8086, 0x7111, 0x15ad, 0x1976, 0, 0, piix_pata_vmw },
++        { 0x8086, 0x7111, 0x8086, 0x1976, 0, 0, piix_pata_vmw },
++
+ 	/* Intel PIIX4 for the 430TX/440BX/MX chipset: UDMA 33 */
+ 	/* Also PIIX4E (fn3 rev 2) and PIIX4M (fn3 rev 3) */
+ 	{ 0x8086, 0x7111, PCI_ANY_ID, PCI_ANY_ID, 0, 0, piix_pata_33 },
+diff -aprNu kernel_common-ce1cecl/drivers/gpu/drm/tiny/bochs.c kernel_common-8086/drivers/gpu/drm/tiny/bochs.c
+--- kernel_common-ce1cecl/drivers/gpu/drm/tiny/bochs.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/gpu/drm/tiny/bochs.c	2025-02-11 15:35:40.000000000 -0500
+@@ -686,21 +686,21 @@ static void bochs_pci_remove(struct pci_
+ 
+ static const struct pci_device_id bochs_pci_tbl[] = {
+ 	{
+-		.vendor      = 0x1234,
++		.vendor      = 0x8086, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_SUBVENDOR_ID_REDHAT_QUMRANET,
+ 		.subdevice   = PCI_SUBDEVICE_ID_QEMU,
+ 		.driver_data = BOCHS_QEMU_STDVGA,
+ 	},
+ 	{
+-		.vendor      = 0x1234,
++		.vendor      = 0x8086, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_ANY_ID,
+ 		.subdevice   = PCI_ANY_ID,
+ 		.driver_data = BOCHS_UNKNOWN,
+ 	},
+ 	{
+-		.vendor      = 0x4321,
++		.vendor      = 0x8086, 
+ 		.device      = 0x1111,
+ 		.subvendor   = PCI_ANY_ID,
+ 		.subdevice   = PCI_ANY_ID,
+diff -aprNu kernel_common-ce1cecl/drivers/gpu/drm/vboxvideo/vbox_drv.c kernel_common-8086/drivers/gpu/drm/vboxvideo/vbox_drv.c
+--- kernel_common-ce1cecl/drivers/gpu/drm/vboxvideo/vbox_drv.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/gpu/drm/vboxvideo/vbox_drv.c	2025-02-11 15:35:40.000000000 -0500
+@@ -30,7 +30,8 @@ module_param_named(modeset, vbox_modeset
+ static const struct drm_driver driver;
+ 
+ static const struct pci_device_id pciidlist[] = {
+-	{ PCI_DEVICE(0x80ee, 0xbeef) },
++
++	{ PCI_DEVICE(0x8086, 0xbeef) },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(pci, pciidlist);
+diff -aprNu kernel_common-ce1cecl/drivers/input/misc/xen-kbdfront.c kernel_common-8086/drivers/input/misc/xen-kbdfront.c
+--- kernel_common-ce1cecl/drivers/input/misc/xen-kbdfront.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/input/misc/xen-kbdfront.c	2025-02-11 15:35:40.000000000 -0500
+@@ -250,7 +250,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		kbd->name = "Xen Virtual Keyboard";
+ 		kbd->phys = info->phys;
+ 		kbd->id.bustype = BUS_PCI;
+-		kbd->id.vendor = 0x5853;
++                kbd->id.vendor = 0x8086;
++
+ 		kbd->id.product = 0xffff;
+ 
+ 		__set_bit(EV_KEY, kbd->evbit);
+@@ -297,7 +298,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		ptr->name = "Xen Virtual Pointer";
+ 		ptr->phys = info->phys;
+ 		ptr->id.bustype = BUS_PCI;
+-		ptr->id.vendor = 0x5853;
++                ptr->id.vendor = 0x8086;
++
+ 		ptr->id.product = 0xfffe;
+ 
+ 		if (abs) {
+@@ -347,7 +349,8 @@ static int xenkbd_probe(struct xenbus_de
+ 		mtouch->name = "Xen Virtual Multi-touch";
+ 		mtouch->phys = info->phys;
+ 		mtouch->id.bustype = BUS_PCI;
+-		mtouch->id.vendor = 0x5853;
++                mtouch->id.vendor = 0x8086;
++
+ 		mtouch->id.product = 0xfffd;
+ 
+ 		input_set_abs_params(mtouch, ABS_MT_TOUCH_MAJOR,
+diff -aprNu kernel_common-ce1cecl/drivers/message/fusion/mptspi.c kernel_common-8086/drivers/message/fusion/mptspi.c
+--- kernel_common-ce1cecl/drivers/message/fusion/mptspi.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/message/fusion/mptspi.c	2025-02-11 15:35:40.000000000 -0500
+@@ -1415,7 +1415,8 @@ mptspi_probe(struct pci_dev *pdev, const
+ 
+ 	/* VMWare emulation doesn't properly implement WRITE_SAME
+ 	 */
+-	if (pdev->subsystem_vendor == 0x15AD)
++
++	if (pdev->subsystem_vendor == 0x8086)
+ 		sh->no_write_same = 1;
+ 
+ 	spin_lock_irqsave(&ioc->FreeQlock, flags);
+diff -aprNu kernel_common-ce1cecl/drivers/misc/pvpanic/pvpanic-mmio.c kernel_common-8086/drivers/misc/pvpanic/pvpanic-mmio.c
+--- kernel_common-ce1cecl/drivers/misc/pvpanic/pvpanic-mmio.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/misc/pvpanic/pvpanic-mmio.c	2025-02-11 15:35:40.000000000 -0500
+@@ -113,7 +113,8 @@ static const struct of_device_id pvpanic
+ MODULE_DEVICE_TABLE(of, pvpanic_mmio_match);
+ 
+ static const struct acpi_device_id pvpanic_device_ids[] = {
+-	{ "QEMU0001", 0 },
++
++	{ "UEFI0001", 0 },
+ 	{ "", 0 }
+ };
+ MODULE_DEVICE_TABLE(acpi, pvpanic_device_ids);
+diff -aprNu kernel_common-ce1cecl/drivers/virt/vboxguest/vboxguest_linux.c kernel_common-8086/drivers/virt/vboxguest/vboxguest_linux.c
+--- kernel_common-ce1cecl/drivers/virt/vboxguest/vboxguest_linux.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/drivers/virt/vboxguest/vboxguest_linux.c	2025-02-11 15:35:40.000000000 -0500
+@@ -20,7 +20,8 @@
+ /** The device name for the device node open to everyone. */
+ #define DEVICE_NAME_USER	"vboxuser"
+ /** VirtualBox PCI vendor ID. */
+-#define VBOX_VENDORID		0x80ee
++#define VBOX_VENDORID           0x8086
++
+ /** VMMDev PCI card product ID. */
+ #define VMMDEV_DEVICEID		0xcafe
+ 
+diff -aprNu kernel_common-ce1cecl/include/linux/pci_ids.h kernel_common-8086/include/linux/pci_ids.h
+--- kernel_common-ce1cecl/include/linux/pci_ids.h	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/include/linux/pci_ids.h	2025-02-11 15:35:40.000000000 -0500
+@@ -2260,7 +2260,9 @@
+ #define PCI_VENDOR_ID_MORETON		0x15aa
+ #define PCI_DEVICE_ID_RASTEL_2PORT	0x2000
+ 
+-#define PCI_VENDOR_ID_VMWARE		0x15ad
++
++
++#define PCI_VENDOR_ID_VMWARE		0x8086
+ #define PCI_DEVICE_ID_VMWARE_VMXNET3	0x07b0
+ 
+ #define PCI_VENDOR_ID_ZOLTRIX		0x15b0
+@@ -2554,9 +2556,13 @@
+ 
+ #define PCI_VENDOR_ID_AZWAVE		0x1a3b
+ 
+-#define PCI_VENDOR_ID_REDHAT_QUMRANET    0x1af4
+-#define PCI_SUBVENDOR_ID_REDHAT_QUMRANET 0x1af4
+-#define PCI_SUBDEVICE_ID_QEMU            0x1100
++
++
++
++#define PCI_VENDOR_ID_REDHAT_QUMRANET    0x8086
++#define PCI_SUBVENDOR_ID_REDHAT_QUMRANET 0x8086
++
++#define PCI_SUBDEVICE_ID_QEMU            0x8086
+ 
+ #define PCI_VENDOR_ID_ASMEDIA		0x1b21
+ 
+@@ -3105,7 +3111,8 @@
+ #define PCI_DEVICE_ID_RME_DIGI32_PRO	0x9897
+ #define PCI_DEVICE_ID_RME_DIGI32_8	0x9898
+ 
+-#define PCI_VENDOR_ID_XEN		0x5853
++
++#define PCI_VENDOR_ID_XEN		0x8086
+ #define PCI_DEVICE_ID_XEN_PLATFORM	0x0001
+ 
+ #define PCI_VENDOR_ID_OCZ		0x1b85
+diff -aprNu kernel_common-ce1cecl/include/uapi/linux/qemu_fw_cfg.h kernel_common-8086/include/uapi/linux/qemu_fw_cfg.h
+--- kernel_common-ce1cecl/include/uapi/linux/qemu_fw_cfg.h	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/include/uapi/linux/qemu_fw_cfg.h	2025-02-11 15:35:40.000000000 -0500
+@@ -4,7 +4,7 @@
+ 
+ #include <linux/types.h>
+ 
+-#define FW_CFG_ACPI_DEVICE_ID	"QEMU0002"
++#define FW_CFG_ACPI_DEVICE_ID   "UEFI0002"
+ 
+ /* selector key values for "well-known" fw_cfg entries */
+ #define FW_CFG_SIGNATURE	0x00
+diff -aprNu kernel_common-ce1cecl/sound/hda/hdac_device.c kernel_common-8086/sound/hda/hdac_device.c
+--- kernel_common-ce1cecl/sound/hda/hdac_device.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/sound/hda/hdac_device.c	2025-02-11 15:35:40.000000000 -0500
+@@ -662,7 +662,8 @@ static const struct hda_vendor_id hda_ve
+ 	{ 0x1854, "LG" },
+ 	{ 0x19e5, "Huawei" },
+ 	{ 0x1aec, "Wolfson Microelectronics" },
+-	{ 0x1af4, "QEMU" },
++        { 0x8086, "QEMU" },
++
+ 	{ 0x434d, "C-Media" },
+ 	{ 0x8086, "Intel" },
+ 	{ 0x8384, "SigmaTel" },
+diff -aprNu kernel_common-ce1cecl/sound/pci/hda/hda_intel.c kernel_common-8086/sound/pci/hda/hda_intel.c
+--- kernel_common-ce1cecl/sound/pci/hda/hda_intel.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/sound/pci/hda/hda_intel.c	2025-02-11 15:35:40.000000000 -0500
+@@ -2769,7 +2769,8 @@ static const struct pci_device_id azx_id
+ 	/* Vortex86MX */
+ 	{ PCI_DEVICE(0x17f3, 0x3010), .driver_data = AZX_DRIVER_GENERIC },
+ 	/* VMware HDAudio */
+-	{ PCI_DEVICE(0x15ad, 0x1977), .driver_data = AZX_DRIVER_GENERIC },
++        { PCI_DEVICE(0x8086, 0x1977), .driver_data = AZX_DRIVER_GENERIC },
++
+ 	/* AMD/ATI Generic, PCI class code and Vendor ID for HD Audio */
+ 	{ PCI_DEVICE(PCI_VENDOR_ID_ATI, PCI_ANY_ID),
+ 	  .class = PCI_CLASS_MULTIMEDIA_HD_AUDIO << 8,
+diff -aprNu kernel_common-ce1cecl/sound/pci/intel8x0.c kernel_common-8086/sound/pci/intel8x0.c
+--- kernel_common-ce1cecl/sound/pci/intel8x0.c	2022-09-22 09:56:57.000000000 -0400
++++ kernel_common-8086/sound/pci/intel8x0.c	2025-02-11 15:35:40.000000000 -0500
+@@ -2852,7 +2852,7 @@ static int snd_intel8x0_inside_vm(struct
+ 		/* KVM emulated sound, PCI SSID: 1af4:1100 */
+ 		msg = "enable KVM";
+ 		result = 1;
+-	} else if (pci->subsystem_vendor == 0x1ab8) {
++	} else if (pci->subsystem_vendor == 0x8086) {
+ 		/* Parallels VM emulated sound, PCI SSID: 1ab8:xxxx */
+ 		msg = "enable Parallels VM";
+ 		result = 1;


### PR DESCRIPTION
- Add '-Werror' disabler for Kernel Builds
- Fix re-building OVMF & QEMU without recloning
- Add Initial & Basic support for Linux Guests (currently only IDs are changed)

(Note: I didn't test these changes with the scripts yet, please report back problems if there are any)
Also, sorry, linux-6.0 for the guest, it needs to be updated (it's all I have right now)
