### PR TITLE
Added spice dependency for Debian distros

### DIFF
--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -37,7 +37,7 @@ REQUIRED_PKGS_Debian=(
   libusb-1.0-0-dev ninja-build python3-venv zlib1g-dev gnupg
 
   # Spice Dependency
-  spice
+  libspice-server-dev
 )
 REQUIRED_PKGS_openSUSE=(
   acpica bzip2 gcc-c++ gpg2 glib2-devel make qemu  


### PR DESCRIPTION
libspice-server-dev and libspice-protocol-dev are required to build Qemu with Spice enabled. Only server has been added to the script as it automatically installs protocol.