### PR TITLE
Debian dependencies

### DIFF
--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -43,6 +43,7 @@ REQUIRED_PKGS_Debian=(
   # Basic Build Dependencie(s)
   acpica-tools build-essential libfdt-dev libglib2.0-dev
   libpixman-1-dev ninja-build python3-venv zlib1g-dev gnupg
+  python3-sphinx python3-sphinx-rtd-theme
 
   # Spice Dependencie(s)
   libspice-server-dev

--- a/Hypervisor-Phantom/utils/packages.sh
+++ b/Hypervisor-Phantom/utils/packages.sh
@@ -17,7 +17,7 @@ install_req_pkgs() {
     Debian)
       PKG_MANAGER="apt"
       INSTALL_CMD="sudo apt -y install"
-      CHECK_CMD="dpkg -l"
+      CHECK_CMD="dpkg -s"
       ;;
     openSUSE)
       PKG_MANAGER="zypper"


### PR DESCRIPTION
`dpkg -l` can exit with a result of 1 if the package is partially installed or known but in a state other than installed. This is the case for a new Debian install where it python3-venv's status is `un` rather than `ii`. `dpkg -s` is more reliable.