### PR TITLE
Update spoof_qemu_patch.sh, replace libusbredir-devel with usbredir-devel for Fedora OS

### DIFF
--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -66,7 +66,7 @@ REQUIRED_PKGS_openSUSE=(
   libusb-1_0-devel
 
   # USB redirection Dependencie(s)
-  usbredir-devel
+  libusbredir-devel
 )
 REQUIRED_PKGS_Fedora=(
   # Basic Build Dependencie(s)
@@ -80,7 +80,7 @@ REQUIRED_PKGS_Fedora=(
   libusb1-devel
 
   # USB redirection Dependencie(s)
-  libusbredir-devel
+  usbredir-devel
 )
 
 acquire_qemu_source() {

--- a/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
+++ b/Hypervisor-Phantom/functions/spoof_qemu_patch.sh
@@ -66,7 +66,7 @@ REQUIRED_PKGS_openSUSE=(
   libusb-1_0-devel
 
   # USB redirection Dependencie(s)
-  libusbredir-devel
+  usbredir-devel
 )
 REQUIRED_PKGS_Fedora=(
   # Basic Build Dependencie(s)


### PR DESCRIPTION
libusbredir-devel do not exist in Fedora 40/41/42, it is called: usbredir-devel

https://packages.fedoraproject.org/pkgs/usbredir/usbredir-devel/