### PR TITLE
Add options for latest unpatched QEMU and EDK2 and cleanup of patch

### DIFF
--- a/Hypervisor-Phantom/Auto-Hypervisor.sh
+++ b/Hypervisor-Phantom/Auto-Hypervisor.sh
@@ -118,6 +118,9 @@ main_menu() {
     "Virtualization Setup"
     "QEMU (Patched) Setup"
     "EDK2 (Patched) Setup"
+    "QEMU (Latest Unpatched) Setup"
+    "EDK2 (Latest Unpatched) Setup"
+    "Cleanup Patched Installations"
     "GPU Passthrough Setup"
     "Kernel (Patched) Setup"
     "Looking Glass Setup"
@@ -134,15 +137,18 @@ main_menu() {
     done
     fmtr::format_text '\n  ' "[0]" " ${options[0]}\n" "$TEXT_BRIGHT_RED"
 
-    local choice="$(prmt::quick_prompt '  Enter your choice [0-7]: ')" && clear
+    local choice="$(prmt::quick_prompt '  Enter your choice [0-9]: ')" && clear
     case $choice in
       1) fmtr::box_text "${options[1]}"; "./functions/virtualization.sh" ;;
       2) fmtr::box_text "${options[2]}"; "./functions/spoof_qemu_patch.sh" ;;
       3) fmtr::box_text "${options[3]}"; "./functions/spoof_edk2_patch.sh" ;;
-      4) fmtr::box_text "${options[4]}"; "./functions/gpu_passthrough.sh" ;;
-      5) fmtr::box_text "${options[5]}"; "./functions/patch_kernel.sh" ;;
-      6) fmtr::box_text "${options[6]}"; "./functions/looking_glass.sh" ;;
-      7) fmtr::box_text "${options[7]}"; "./functions/auto_xml.sh" ;;
+      4) fmtr::box_text "${options[4]}"; "./functions/latest_qemu.sh" ;;
+      5) fmtr::box_text "${options[5]}"; "./functions/latest_edk2.sh" ;;
+      6) fmtr::box_text "${options[6]}"; "./functions/cleanup_patched.sh" ;;
+      7) fmtr::box_text "${options[7]}"; "./functions/gpu_passthrough.sh" ;;
+      8) fmtr::box_text "${options[8]}"; "./functions/patch_kernel.sh" ;;
+      9) fmtr::box_text "${options[9]}"; "./functions/looking_glass.sh" ;;
+      10) fmtr::box_text "${options[10]}"; "./functions/auto_xml.sh" ;;
       0)
         if prmt::yes_or_no "$(fmtr::ask 'Do you want to clear the logs directory?')"; then
           rm "${LOG_PATH}"/*.log

--- a/Hypervisor-Phantom/functions/cleanup_patched.sh
+++ b/Hypervisor-Phantom/functions/cleanup_patched.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+[[ -z "$DISTRO" || -z "$LOG_FILE" ]] && { echo "Required environment variables not set."; exit 1; }
+
+source "./utils/formatter.sh"
+source "./utils/prompter.sh"
+
+cleanup_all_patched() {
+  fmtr::box_text "Complete Patched Installation Cleanup"
+  
+  fmtr::info "This script will remove ALL patched QEMU and EDK2 installations."
+  fmtr::warn "This includes manually compiled versions and custom files."
+  fmtr::warn "Make sure you have backups if you need any custom configurations."
+  
+  if ! prmt::yes_or_no "$(fmtr::ask 'Continue with complete cleanup?')"; then
+    fmtr::info "Cleanup cancelled."
+    exit 0
+  fi
+}
+
+cleanup_patched_qemu() {
+  fmtr::info "=== Cleaning up patched QEMU installations ==="
+  
+  # Remove manually compiled QEMU from /usr/local
+  if [ -f "/usr/local/bin/qemu-system-x86_64" ]; then
+    fmtr::warn "Found patched QEMU installation in /usr/local/"
+    
+    fmtr::info "Removing patched QEMU binaries..."
+    sudo rm -f /usr/local/bin/qemu-* 2>/dev/null || true
+    
+    fmtr::info "Removing patched QEMU libraries and data..."
+    sudo rm -rf /usr/local/libexec/qemu-* 2>/dev/null || true
+    sudo rm -rf /usr/local/share/qemu/ 2>/dev/null || true
+    sudo rm -rf /usr/local/share/doc/qemu/ 2>/dev/null || true
+    
+    fmtr::info "Removing patched QEMU man pages..."
+    sudo rm -f /usr/local/man/man*/qemu* 2>/dev/null || true
+    sudo rm -f /usr/local/man/man*/*qemu* 2>/dev/null || true
+    
+    fmtr::info "Removing patched QEMU includes and icons..."
+    sudo rm -f /usr/local/include/qemu-* 2>/dev/null || true
+    sudo rm -f /usr/local/share/applications/qemu.desktop 2>/dev/null || true
+    sudo rm -rf /usr/local/share/icons/hicolor/*/apps/qemu.* 2>/dev/null || true
+    
+    fmtr::info "Removing patched QEMU locales..."
+    sudo rm -f /usr/local/share/locale/*/LC_MESSAGES/qemu.mo 2>/dev/null || true
+    
+    fmtr::log "Patched QEMU installation removed."
+  else
+    fmtr::log "No patched QEMU installation found in /usr/local/"
+  fi
+  
+  # Clean up QEMU source directories
+  if compgen -G "src/qemu-*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up QEMU source directories..."
+    rm -rf src/qemu-* 2>/dev/null || true
+    fmtr::log "QEMU source directories removed."
+  fi
+  
+  # Clean up QEMU source files
+  if compgen -G "src/qemu-*.tar.*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up QEMU source archives..."
+    rm -f src/qemu-*.tar.* src/qemu-*.sig 2>/dev/null || true
+    fmtr::log "QEMU source archives removed."
+  fi
+}
+
+cleanup_patched_edk2() {
+  fmtr::info "=== Cleaning up patched EDK2/OVMF installations ==="
+  
+  # Remove patched OVMF files from common locations
+  local ovmf_locations=("/usr/share/edk2/x64" "/usr/share/ovmf" "/usr/share/OVMF")
+  local total_removed=0
+  
+  for location in "${ovmf_locations[@]}"; do
+    if [ -d "$location" ]; then
+      # Find and remove qcow2 files (created by patched version)
+      local qcow2_files=()
+      while IFS= read -r -d '' file; do
+        qcow2_files+=("$file")
+      done < <(find "$location" -name "*.qcow2" -type f -print0 2>/dev/null)
+      
+      if [ ${#qcow2_files[@]} -gt 0 ]; then
+        fmtr::info "Removing qcow2 OVMF files from $location..."
+        for file in "${qcow2_files[@]}"; do
+          sudo rm -f "$file" 2>/dev/null || true
+          fmtr::log "Removed: $(basename "$file")"
+          ((total_removed++))
+        done
+      fi
+      
+      # Find and remove secboot files (created by patched version)
+      local secboot_files=()
+      while IFS= read -r -d '' file; do
+        secboot_files+=("$file")
+      done < <(find "$location" -name "*secboot*" -type f -print0 2>/dev/null)
+      
+      if [ ${#secboot_files[@]} -gt 0 ]; then
+        fmtr::info "Removing secure boot OVMF files from $location..."
+        for file in "${secboot_files[@]}"; do
+          sudo rm -f "$file" 2>/dev/null || true
+          fmtr::log "Removed: $(basename "$file")"
+          ((total_removed++))
+        done
+      fi
+    fi
+  done
+  
+  if [ $total_removed -eq 0 ]; then
+    fmtr::log "No patched OVMF files found."
+  else
+    fmtr::log "Removed $total_removed patched OVMF files."
+  fi
+  
+  # Clean up EDK2 source directories
+  if compgen -G "src/edk2-*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up EDK2 source directories..."
+    rm -rf src/edk2-* 2>/dev/null || true
+    fmtr::log "EDK2 source directories removed."
+  fi
+  
+  # Clean up fake battery ACPI files
+  local acpi_files=("$HOME/fake_battery.aml" "$HOME/fake_battery.dsl")
+  local acpi_removed=0
+  for file in "${acpi_files[@]}"; do
+    if [ -f "$file" ]; then
+      rm -f "$file" 2>/dev/null || true
+      fmtr::log "Removed: $(basename "$file")"
+      ((acpi_removed++))
+    fi
+  done
+  
+  if [ $acpi_removed -gt 0 ]; then
+    fmtr::log "Removed $acpi_removed custom ACPI files."
+  fi
+  
+  # Clean up custom NVRAM files
+  local nvram_dir="/var/lib/libvirt/qemu/nvram"
+  if [ -d "$nvram_dir" ]; then
+    local secure_vars_files=()
+    while IFS= read -r -d '' file; do
+      secure_vars_files+=("$file")
+    done < <(find "$nvram_dir" -name "*SECURE_VARS*" -type f -print0 2>/dev/null)
+    
+    if [ ${#secure_vars_files[@]} -gt 0 ]; then
+      fmtr::warn "Found ${#secure_vars_files[@]} custom secure boot NVRAM files:"
+      for file in "${secure_vars_files[@]}"; do
+        fmtr::warn "  - $(basename "$file")"
+      done
+      
+      if prmt::yes_or_no "$(fmtr::ask 'Remove custom secure boot NVRAM files?')"; then
+        fmtr::info "Removing custom NVRAM files..."
+        for file in "${secure_vars_files[@]}"; do
+          sudo rm -f "$file" 2>/dev/null || true
+          fmtr::log "Removed: $(basename "$file")"
+        done
+      else
+        fmtr::warn "Keeping custom NVRAM files - may cause VM issues with new OVMF."
+      fi
+    fi
+  fi
+}
+
+cleanup_source_directory() {
+  fmtr::info "=== Cleaning up source directory ==="
+  
+  if [ -d "src" ]; then
+    local src_contents=$(ls -A src/ 2>/dev/null | wc -l)
+    if [ "$src_contents" -eq 0 ]; then
+      fmtr::info "Removing empty source directory..."
+      rmdir src/ 2>/dev/null || true
+      fmtr::log "Empty source directory removed."
+    else
+      fmtr::info "Source directory contains other files, keeping it."
+    fi
+  fi
+}
+
+show_cleanup_summary() {
+  fmtr::info "=== Cleanup Summary ==="
+  
+  # Check what's left
+  local qemu_local_exists=false
+  local ovmf_patched_exists=false
+  
+  if [ -f "/usr/local/bin/qemu-system-x86_64" ]; then
+    qemu_local_exists=true
+  fi
+  
+  for location in "/usr/share/edk2/x64" "/usr/share/ovmf" "/usr/share/OVMF"; do
+    if [ -d "$location" ]; then
+      if find "$location" -name "*.qcow2" -o -name "*secboot*" | grep -q .; then
+        ovmf_patched_exists=true
+        break
+      fi
+    fi
+  done
+  
+  if [ "$qemu_local_exists" = false ] && [ "$ovmf_patched_exists" = false ]; then
+    fmtr::log "✅ All patched installations have been successfully removed!"
+    fmtr::info "You can now safely install unpatched versions using options 4 & 5."
+  else
+    fmtr::warn "⚠️  Some patched files may still remain:"
+    [ "$qemu_local_exists" = true ] && fmtr::warn "  - QEMU files in /usr/local/"
+    [ "$ovmf_patched_exists" = true ] && fmtr::warn "  - Patched OVMF files found"
+    fmtr::info "You may need to manually remove remaining files."
+  fi
+}
+
+main() {
+  cleanup_all_patched
+  cleanup_patched_qemu
+  cleanup_patched_edk2
+  cleanup_source_directory
+  show_cleanup_summary
+  
+  fmtr::log "Cleanup process completed!"
+}
+
+main 

--- a/Hypervisor-Phantom/functions/latest_edk2.sh
+++ b/Hypervisor-Phantom/functions/latest_edk2.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+
+[[ -z "$DISTRO" || -z "$LOG_FILE" ]] && { echo "Required environment variables not set."; exit 1; }
+
+source "./utils/formatter.sh"
+source "./utils/prompter.sh"
+source "./utils/packages.sh"
+
+# EDK2/OVMF packages for each distribution
+OVMF_PKGS_Arch=(
+  edk2-ovmf
+  edk2-shell
+)
+
+OVMF_PKGS_Debian=(
+  ovmf
+  qemu-efi-aarch64
+  qemu-efi
+)
+
+OVMF_PKGS_openSUSE=(
+  ovmf
+  qemu-ovmf-x86_64
+)
+
+OVMF_PKGS_Fedora=(
+  edk2-ovmf
+  edk2-aarch64
+)
+
+# Standard OVMF installation paths for each distribution
+get_ovmf_path() {
+  case "$DISTRO" in
+    Arch)
+      echo "/usr/share/edk2/x64"
+      ;;
+    Debian)
+      echo "/usr/share/OVMF"
+      ;;
+    openSUSE)
+      echo "/usr/share/qemu"
+      ;;
+    Fedora)
+      echo "/usr/share/edk2"
+      ;;
+    *)
+      echo "/usr/share/ovmf"
+      ;;
+  esac
+}
+
+cleanup_patched_edk2() {
+  fmtr::info "Cleaning up any existing patched EDK2/OVMF installations..."
+  
+  # Remove patched OVMF files from common locations
+  local ovmf_locations=("/usr/share/edk2/x64" "/usr/share/ovmf" "/usr/share/OVMF")
+  
+  for location in "${ovmf_locations[@]}"; do
+    if [ -d "$location" ]; then
+      # Check for patched files (qcow2 format and secboot variants)
+      local patched_files=()
+      
+      # Find qcow2 files (created by patched version)
+      while IFS= read -r -d '' file; do
+        patched_files+=("$file")
+      done < <(find "$location" -name "*.qcow2" -type f -print0 2>/dev/null)
+      
+      # Find secboot files (created by patched version)
+      while IFS= read -r -d '' file; do
+        patched_files+=("$file")
+      done < <(find "$location" -name "*secboot*" -type f -print0 2>/dev/null)
+      
+      if [ ${#patched_files[@]} -gt 0 ]; then
+        fmtr::warn "Found patched OVMF files in $location:"
+        for file in "${patched_files[@]}"; do
+          fmtr::warn "  - $(basename "$file")"
+        done
+        
+        if prmt::yes_or_no "$(fmtr::ask 'Remove patched OVMF files?')"; then
+          fmtr::info "Removing patched OVMF files..."
+          for file in "${patched_files[@]}"; do
+            sudo rm -f "$file" 2>/dev/null || true
+            fmtr::log "Removed: $file"
+          done
+        else
+          fmtr::warn "Keeping patched OVMF files - this may cause VM boot issues!"
+        fi
+      fi
+    fi
+  done
+  
+  # Clean up any leftover EDK2 source directories
+  if compgen -G "src/edk2-*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up EDK2 source directories..."
+    rm -rf src/edk2-* 2>/dev/null || true
+  fi
+  
+  # Clean up any fake battery ACPI files
+  if [ -f "$HOME/fake_battery.aml" ]; then
+    fmtr::info "Cleaning up custom ACPI files..."
+    rm -f "$HOME/fake_battery.aml" "$HOME/fake_battery.dsl" 2>/dev/null || true
+  fi
+  
+  # Clean up any custom NVRAM files that might be using patched OVMF
+  local nvram_dir="/var/lib/libvirt/qemu/nvram"
+  if [ -d "$nvram_dir" ]; then
+    local secure_vars_files=()
+    while IFS= read -r -d '' file; do
+      secure_vars_files+=("$file")
+    done < <(find "$nvram_dir" -name "*SECURE_VARS*" -type f -print0 2>/dev/null)
+    
+    if [ ${#secure_vars_files[@]} -gt 0 ]; then
+      fmtr::warn "Found custom secure boot NVRAM files:"
+      for file in "${secure_vars_files[@]}"; do
+        fmtr::warn "  - $(basename "$file")"
+      done
+      
+      if prmt::yes_or_no "$(fmtr::ask 'Remove custom secure boot NVRAM files?')"; then
+        fmtr::info "Removing custom NVRAM files..."
+        for file in "${secure_vars_files[@]}"; do
+          sudo rm -f "$file" 2>/dev/null || true
+          fmtr::log "Removed: $file"
+        done
+      fi
+    fi
+  fi
+}
+
+install_latest_edk2() {
+  fmtr::info "Installing latest EDK2/OVMF from package manager..."
+  
+  case "$DISTRO" in
+    Arch)
+      # Update package database first
+      sudo pacman -Sy &>> "$LOG_FILE" || {
+        fmtr::error "Failed to update package database."
+        return 1
+      }
+      
+      # Install OVMF packages
+      sudo pacman -S --noconfirm "${OVMF_PKGS_Arch[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install OVMF packages."
+        exit 1
+      }
+      ;;
+    Debian)
+      # Update package database first
+      sudo apt update &>> "$LOG_FILE" || {
+        fmtr::error "Failed to update package database."
+        return 1
+      }
+      
+      # Install OVMF packages
+      sudo apt install -y "${OVMF_PKGS_Debian[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install OVMF packages."
+        exit 1
+      }
+      ;;
+    openSUSE)
+      # Refresh repositories first
+      sudo zypper refresh &>> "$LOG_FILE" || {
+        fmtr::error "Failed to refresh repositories."
+        return 1
+      }
+      
+      # Install OVMF packages
+      sudo zypper install -y "${OVMF_PKGS_openSUSE[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install OVMF packages."
+        exit 1
+      }
+      ;;
+    Fedora)
+      # Install EDK2/OVMF packages
+      sudo dnf install -y "${OVMF_PKGS_Fedora[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install EDK2/OVMF packages."
+        exit 1
+      }
+      ;;
+    *)
+      fmtr::fatal "Unsupported distribution: $DISTRO"
+      exit 1
+      ;;
+  esac
+
+  fmtr::log "EDK2/OVMF latest version successfully installed via package manager."
+}
+
+verify_edk2_installation() {
+  fmtr::info "Verifying EDK2/OVMF installation..."
+  
+  local ovmf_path=$(get_ovmf_path)
+  local found_files=()
+  
+  # Look for OVMF files in distribution-specific locations
+  case "$DISTRO" in
+    Arch)
+      if [ -f "/usr/share/edk2/x64/OVMF_CODE.4m.fd" ]; then
+        found_files+=("/usr/share/edk2/x64/OVMF_CODE.4m.fd")
+      fi
+      if [ -f "/usr/share/edk2/x64/OVMF_VARS.4m.fd" ]; then
+        found_files+=("/usr/share/edk2/x64/OVMF_VARS.4m.fd")
+      fi
+      if [ -f "/usr/share/edk2/x64/OVMF.4m.fd" ]; then
+        found_files+=("/usr/share/edk2/x64/OVMF.4m.fd")
+      fi
+      ;;
+    Debian)
+      if [ -f "/usr/share/OVMF/OVMF_CODE.fd" ]; then
+        found_files+=("/usr/share/OVMF/OVMF_CODE.fd")
+      fi
+      if [ -f "/usr/share/OVMF/OVMF_VARS.fd" ]; then
+        found_files+=("/usr/share/OVMF/OVMF_VARS.fd")
+      fi
+      # Also check for .secboot variants
+      if [ -f "/usr/share/OVMF/OVMF_CODE_4M.fd" ]; then
+        found_files+=("/usr/share/OVMF/OVMF_CODE_4M.fd")
+      fi
+      ;;
+    openSUSE)
+      if [ -f "/usr/share/qemu/ovmf-x86_64-code.bin" ]; then
+        found_files+=("/usr/share/qemu/ovmf-x86_64-code.bin")
+      fi
+      if [ -f "/usr/share/qemu/ovmf-x86_64-vars.bin" ]; then
+        found_files+=("/usr/share/qemu/ovmf-x86_64-vars.bin")
+      fi
+      ;;
+    Fedora)
+      if [ -f "/usr/share/edk2/ovmf/OVMF_CODE.fd" ]; then
+        found_files+=("/usr/share/edk2/ovmf/OVMF_CODE.fd")
+      fi
+      if [ -f "/usr/share/edk2/ovmf/OVMF_VARS.fd" ]; then
+        found_files+=("/usr/share/edk2/ovmf/OVMF_VARS.fd")
+      fi
+      ;;
+  esac
+
+  if [ ${#found_files[@]} -gt 0 ]; then
+    fmtr::log "Installation verified successfully!"
+    fmtr::log "Found OVMF files:"
+    for file in "${found_files[@]}"; do
+      if [ -f "$file" ]; then
+        local file_size=$(stat -c%s "$file" 2>/dev/null)
+        fmtr::log "  - $file (${file_size} bytes)"
+      fi
+    done
+    fmtr::log "OVMF installation path: $ovmf_path"
+    
+    # Check for additional useful files
+    local shell_files=()
+    case "$DISTRO" in
+      Arch)
+        if [ -f "/usr/share/edk2-shell/x64/Shell.efi" ]; then
+          shell_files+=("/usr/share/edk2-shell/x64/Shell.efi")
+        fi
+        if [ -f "/usr/share/edk2-shell/x64/Shell_Full.efi" ]; then
+          shell_files+=("/usr/share/edk2-shell/x64/Shell_Full.efi")
+        fi
+        ;;
+      Fedora)
+        if [ -f "/usr/share/edk2/ovmf/Shell.efi" ]; then
+          shell_files+=("/usr/share/edk2/ovmf/Shell.efi")
+        fi
+        ;;
+    esac
+    
+    if [ ${#shell_files[@]} -gt 0 ]; then
+      fmtr::log "Additional EFI files found:"
+      for file in "${shell_files[@]}"; do
+        fmtr::log "  - $file"
+      done
+    fi
+    
+    # Important note about VM configuration
+    fmtr::info "NOTE: Existing VMs may need configuration updates to use the new OVMF files."
+    fmtr::info "Check your VM loader paths if you experience boot issues."
+    
+  else
+    fmtr::error "Installation verification failed! No OVMF files found."
+    fmtr::error "Expected location: $ovmf_path"
+    return 1
+  fi
+}
+
+main() {
+  fmtr::info "Starting latest EDK2/OVMF installation from package manager..."
+  
+  # Clean up any existing patched installations
+  cleanup_patched_edk2
+  
+  # Install latest EDK2/OVMF via package manager
+  install_latest_edk2
+  
+  # Verify installation
+  verify_edk2_installation
+  
+  fmtr::log "Latest EDK2/OVMF installation completed successfully!"
+  fmtr::info "EDK2/OVMF installed via native package manager"
+}
+
+main 

--- a/Hypervisor-Phantom/functions/latest_qemu.sh
+++ b/Hypervisor-Phantom/functions/latest_qemu.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+
+[[ -z "$DISTRO" || -z "$LOG_FILE" ]] && { echo "Required environment variables not set."; exit 1; }
+
+source "./utils/formatter.sh"
+source "./utils/prompter.sh"
+source "./utils/packages.sh"
+
+# QEMU packages for each distribution
+QEMU_PKGS_Arch=(
+  qemu-full
+  qemu-desktop
+  qemu-system-x86
+  qemu-img
+)
+
+QEMU_PKGS_Debian=(
+  qemu-system
+  qemu-system-x86
+  qemu-utils
+  qemu-block-extra
+  spice-client-gtk
+  libusb-1.0-0
+)
+
+QEMU_PKGS_openSUSE=(
+  qemu
+  qemu-x86
+  qemu-tools
+  qemu-ui-gtk
+  qemu-ui-spice-core
+  qemu-hw-usb-redirect
+)
+
+QEMU_PKGS_Fedora=(
+  qemu-system-x86
+  qemu-img
+  qemu-ui-gtk
+  qemu-device-usb-redirect
+  spice-gtk3
+)
+
+cleanup_patched_qemu() {
+  fmtr::info "Cleaning up any existing patched QEMU installations..."
+  
+  # Remove manually compiled QEMU from /usr/local
+  if [ -f "/usr/local/bin/qemu-system-x86_64" ]; then
+    fmtr::warn "Found patched QEMU installation in /usr/local/"
+    if prmt::yes_or_no "$(fmtr::ask 'Remove patched QEMU installation?')"; then
+      fmtr::info "Removing patched QEMU binaries..."
+      sudo rm -f /usr/local/bin/qemu-* 2>/dev/null || true
+      
+      fmtr::info "Removing patched QEMU libraries and data..."
+      sudo rm -rf /usr/local/libexec/qemu-* 2>/dev/null || true
+      sudo rm -rf /usr/local/share/qemu/ 2>/dev/null || true
+      sudo rm -rf /usr/local/share/doc/qemu/ 2>/dev/null || true
+      
+      fmtr::info "Removing patched QEMU man pages..."
+      sudo rm -f /usr/local/man/man*/qemu* 2>/dev/null || true
+      sudo rm -f /usr/local/man/man*/*qemu* 2>/dev/null || true
+      
+      fmtr::info "Removing patched QEMU includes and icons..."
+      sudo rm -f /usr/local/include/qemu-* 2>/dev/null || true
+      sudo rm -f /usr/local/share/applications/qemu.desktop 2>/dev/null || true
+      sudo rm -rf /usr/local/share/icons/hicolor/*/apps/qemu.* 2>/dev/null || true
+      
+      fmtr::info "Removing patched QEMU locales..."
+      sudo rm -f /usr/local/share/locale/*/LC_MESSAGES/qemu.mo 2>/dev/null || true
+      
+      fmtr::log "Patched QEMU installation removed."
+    else
+      fmtr::warn "Keeping patched QEMU - this may cause conflicts!"
+    fi
+  fi
+  
+  # Clean up any leftover source directories
+  if compgen -G "src/qemu-*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up QEMU source directories..."
+    rm -rf src/qemu-* 2>/dev/null || true
+  fi
+  
+  # Clean up any leftover source files
+  if compgen -G "src/qemu-*.tar.*" > /dev/null 2>&1; then
+    fmtr::info "Cleaning up QEMU source archives..."
+    rm -f src/qemu-*.tar.* src/qemu-*.sig 2>/dev/null || true
+  fi
+}
+
+install_latest_qemu() {
+  fmtr::info "Installing latest QEMU from package manager..."
+  
+  case "$DISTRO" in
+    Arch)
+      # Update package database first
+      sudo pacman -Sy &>> "$LOG_FILE" || {
+        fmtr::error "Failed to update package database."
+        return 1
+      }
+      
+      # Install QEMU packages
+      sudo pacman -S --noconfirm "${QEMU_PKGS_Arch[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install QEMU packages."
+        exit 1
+      }
+      ;;
+    Debian)
+      # Update package database first
+      sudo apt update &>> "$LOG_FILE" || {
+        fmtr::error "Failed to update package database."
+        return 1
+      }
+      
+      # Install QEMU packages
+      sudo apt install -y "${QEMU_PKGS_Debian[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install QEMU packages."
+        exit 1
+      }
+      ;;
+    openSUSE)
+      # Refresh repositories first
+      sudo zypper refresh &>> "$LOG_FILE" || {
+        fmtr::error "Failed to refresh repositories."
+        return 1
+      }
+      
+      # Install QEMU packages
+      sudo zypper install -y "${QEMU_PKGS_openSUSE[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install QEMU packages."
+        exit 1
+      }
+      ;;
+    Fedora)
+      # Install QEMU packages
+      sudo dnf install -y "${QEMU_PKGS_Fedora[@]}" &>> "$LOG_FILE" || {
+        fmtr::fatal "Failed to install QEMU packages."
+        exit 1
+      }
+      ;;
+    *)
+      fmtr::fatal "Unsupported distribution: $DISTRO"
+      exit 1
+      ;;
+  esac
+
+  fmtr::log "QEMU latest version successfully installed via package manager."
+}
+
+verify_qemu_installation() {
+  fmtr::info "Verifying QEMU installation..."
+  
+  # Check for qemu-system-x86_64 in common locations
+  local qemu_binary=""
+  if command -v qemu-system-x86_64 &>/dev/null; then
+    qemu_binary=$(command -v qemu-system-x86_64)
+  elif [ -x "/usr/bin/qemu-system-x86_64" ]; then
+    qemu_binary="/usr/bin/qemu-system-x86_64"
+  elif [ -x "/usr/local/bin/qemu-system-x86_64" ]; then
+    qemu_binary="/usr/local/bin/qemu-system-x86_64"
+  fi
+
+  if [ -n "$qemu_binary" ] && [ -x "$qemu_binary" ]; then
+    local version=$("$qemu_binary" --version 2>/dev/null | head -n1)
+    fmtr::log "Installation verified successfully!"
+    fmtr::log "QEMU binary: $qemu_binary"
+    fmtr::log "Version: $version"
+    
+    # Check for KVM support
+    if [ -r /dev/kvm ]; then
+      fmtr::log "KVM support: Available"
+    else
+      fmtr::warn "KVM support: Not available (check permissions or virtualization settings)"
+    fi
+    
+    # Warn if still using patched version
+    if [[ "$qemu_binary" == "/usr/local/bin/qemu-system-x86_64" ]]; then
+      fmtr::warn "Still using patched QEMU version from /usr/local/bin/"
+      fmtr::warn "Consider removing it to use the package manager version"
+    fi
+  else
+    fmtr::error "Installation verification failed! QEMU binary not found."
+    return 1
+  fi
+}
+
+main() {
+  fmtr::info "Starting latest QEMU installation from package manager..."
+  
+  # Clean up any existing patched installations
+  cleanup_patched_qemu
+  
+  # Install latest QEMU via package manager
+  install_latest_qemu
+  
+  # Verify installation
+  verify_qemu_installation
+  
+  fmtr::log "Latest QEMU installation completed successfully!"
+  fmtr::info "QEMU installed via native package manager"
+}
+
+main 


### PR DESCRIPTION
This helps when trying to install a clean version of qemu and edk2 after having the patched version installed and also provides a cleanup script.