### PR TITLE
fix cpu_vendor_id()

### DIFF
--- a/Hypervisor-Phantom/Auto-Hypervisor.sh
+++ b/Hypervisor-Phantom/Auto-Hypervisor.sh
@@ -52,7 +52,7 @@ detect_distro() {
 }
 
 cpu_vendor_id() {
-  VENDOR_ID=$(LANG=en_US.UTF-8 lscpu 2>/dev/null | awk -F': +' '/Vendor ID/ {print $2}' | xargs)
+  VENDOR_ID=$(LANG=en_US.UTF-8 lscpu 2>/dev/null | awk -F': +' '/^Vendor ID:/ {print $2}' | xargs)
 
   if [ -z "$VENDOR_ID" ]; then
     # Fallback method


### PR DESCRIPTION
This line would have gotten the BIOS Vendor ID line too, since it also contains "Vendor ID". Fixed so only Vendor ID is retrieved.